### PR TITLE
Fix flip card template bugs - event bubbling, accessibility, print styles

### DIFF
--- a/template/rg-item-card-template.html
+++ b/template/rg-item-card-template.html
@@ -71,10 +71,6 @@
             background: white;
         }
         
-        .card-back {
-            transform: rotateY(180deg);
-        }
-        
         /* FRONT SIDE */
         .card-front {
             display: flex;
@@ -161,6 +157,7 @@
         
         /* BACK SIDE */
         .card-back {
+            transform: rotateY(180deg);
             display: flex;
             flex-direction: column;
             background: white;
@@ -315,21 +312,29 @@
                 background: white;
                 padding: 0;
             }
-            
+
             .card-container {
                 max-width: 4in;
             }
-            
+
             .flip-card {
                 transform: none !important;
             }
-            
+
+            .card-face {
+                position: relative;
+                box-shadow: none;
+            }
+
+            .card-front {
+                margin-bottom: 0.5in;
+            }
+
             .card-back {
                 transform: rotateY(0) !important;
-                position: relative;
                 page-break-before: always;
             }
-            
+
             .flip-hint, .buy-button {
                 display: none;
             }
@@ -355,7 +360,7 @@
 </head>
 <body>
     <div class="card-container">
-        <div class="flip-card" tabindex="0" role="button" aria-label="Item info card. Press Enter or click to flip.">
+        <div class="flip-card" tabindex="0" role="button" aria-expanded="false" aria-describedby="flip-instructions" aria-label="{{ITEM_TITLE}} info card">
             
             <!-- FRONT SIDE -->
             <div class="card-face card-front">
@@ -431,22 +436,35 @@
             </div>
             
         </div>
+        <span id="flip-instructions" class="sr-only">Press Enter or click to flip between front and back views.</span>
     </div>
-    
-    <span class="sr-only">Press Enter or click the card to flip between front and back views.</span>
     
     <script>
         // Flip card interaction
         const flipCard = document.querySelector('.flip-card');
-        
+
+        // Update aria-expanded state for accessibility
+        const updateAriaState = () => {
+            const isFlipped = flipCard.classList.contains('flipped');
+            flipCard.setAttribute('aria-expanded', isFlipped);
+        };
+
         flipCard.addEventListener('click', () => {
             flipCard.classList.toggle('flipped');
+            updateAriaState();
         });
         
         flipCard.addEventListener('keydown', (e) => {
             if (e.key === 'Enter' || e.key === ' ') {
                 e.preventDefault();
                 flipCard.classList.toggle('flipped');
+                updateAriaState();
+                const isFlipped = flipCard.classList.contains('flipped');
+                trackEvent(isFlipped ? 'card_flip_to_back' : 'card_flip_to_front', {
+                    sku: '{{SKU}}',
+                    method: 'keyboard',
+                    timestamp: new Date().toISOString()
+                });
             }
         });
         
@@ -469,8 +487,9 @@
             });
         });
         
-        // Track payment link clicks
-        document.querySelector('.buy-button')?.addEventListener('click', () => {
+        // Track payment link clicks (stop propagation to prevent card flip)
+        document.querySelector('.buy-button')?.addEventListener('click', (e) => {
+            e.stopPropagation();
             trackEvent('buy_button_click', { sku: '{{SKU}}' });
         });
     </script>


### PR DESCRIPTION
- Fix buy button click causing unwanted card flip (add stopPropagation)
- Add analytics tracking to keyboard navigation (was only on click)
- Fix print styles: make both card faces position:relative for proper layout
- Consolidate duplicate .card-back CSS into single definition
- Add aria-expanded attribute that updates on flip for screen readers
- Fix sr-only text placement with aria-describedby association
- Add updateAriaState function called on both click and keyboard events